### PR TITLE
Correction d'une commande shell dans README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Il est conseillé, hors développeurs, d'utiliser une archive stable mais si vou
 
 Copiez le fichier *parameters.ini.dist* sur *parameters.ini* et adaptez-le à vos besoins (connexion MySQL, etc).
 
-    cp app/config/parameters.ini.dist app/config/parameters.ini
+    cp app/config/parameters.yml.dist app/config/parameters.yml
     ./composer.phar install
 
 Installez la base de données :


### PR DESCRIPTION
Le fichier contenant les paramètres n'est pas `app/config/parameters.ini` mais `app/config/parameters.yml`.